### PR TITLE
Feat/Renewal by index

### DIFF
--- a/components/App.js
+++ b/components/App.js
@@ -9,6 +9,7 @@ import WarningAlertWithSignUp from "../components/WarningAlertWithSignUp";
 import WarningAlertWithLink from "../components/WarningAlertWithLink";
 import NotifyModal from "../components/NotifyModal";
 import SignUpHeader from "../components/SignUpHeader";
+import { SearchIcon } from "@heroicons/react/solid";
 
 const navigation = [{ name: "Names", href: "/", current: true }];
 const userNavigation = [{ name: "Sign out", href: "#" }];
@@ -28,6 +29,7 @@ class App extends React.Component {
   state = {
     showNotifyModal: false,
     showSearchModal: false,
+    targetIndex: 0,
   };
 
   setShowNotifyModal(value) {
@@ -229,12 +231,6 @@ class App extends React.Component {
                           setShowNotifyModal={this.setShowNotifyModal}
                           setShowSearchModal={this.setShowSearchModal}
                         />
-                        <SearchModal
-                          showModal={this.state.showSearchModal}
-                          setShowModal={this.setShowSearchModal}
-                          targetAddress={this.props.walletAddress}
-                          resolveAndAddName={this.props.resolveAndAddName}
-                        />
                       </>
                     ) : (
                       <>
@@ -286,8 +282,45 @@ class App extends React.Component {
                             />
                           </div>
                         ))}
+
+                        <div className="text-center mt-8 mb-8">
+                          <div className="mt-6">
+                            <input
+                              type="number"
+                              value={this.state.targetIndex}
+                              onChange={(e) => {
+                                e.preventDefault();
+                                this.setState({
+                                  targetIndex: e.target.valueAsNumber,
+                                });
+                              }}
+                            ></input>
+                          </div>
+                          <div className="mt-6">
+                            <button
+                              onClick={(e) => {
+                                e.preventDefault();
+                                this.setShowSearchModal(true);
+                              }}
+                              type="button"
+                              className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            >
+                              <SearchIcon
+                                className="-ml-1 mr-2 h-5 w-5"
+                                aria-hidden="true"
+                              />
+                              Search for name by index
+                            </button>
+                          </div>
+                        </div>
                       </>
                     )}
+                    <SearchModal
+                      showModal={this.state.showSearchModal}
+                      setShowModal={this.setShowSearchModal}
+                      resolveAndAddName={this.props.resolveAndAddName}
+                      targetIndex={this.state.targetIndex}
+                    />
                   </ul>
                 </div>
                 {/* /End replace */}

--- a/components/Name.tsx
+++ b/components/Name.tsx
@@ -30,6 +30,7 @@ const Name = (props: {
         showModal={props.showSecretKeyModal}
         setShowModal={props.setShowSecretKeyModal}
         name={props.name}
+        nameAddress={props.address}
         price={props.price}
         targetAddress={props.walletAddress}
         zonefileHash={props.zonefileHash}

--- a/components/SearchModal.js
+++ b/components/SearchModal.js
@@ -161,7 +161,7 @@ export default function SearchModal(props) {
               `index: ${i} - derived address: ${walletAccountAddress} - target address: ${props.targetAddress} - stacks 1.0 identity address ${address}`
             );
 
-            if (walletAccountAddress == props.targetAddress) {
+            if (walletAccountAddress == props.targetAddress || i === props.targetIndex) {
               console.log(`Found account index #${i}.`);
               found = true;
             }
@@ -176,7 +176,7 @@ export default function SearchModal(props) {
                 setNameFound(true);
                 if (name) {
                   const legacy = true;
-                  props.resolveAndAddName(name, legacy);
+                  props.resolveAndAddName(name, legacy, walletAccountAddress);
                 }
               });
               return true;

--- a/pages/index.js
+++ b/pages/index.js
@@ -178,33 +178,54 @@ class Index extends React.Component {
     }
   }
 
-  resolveAndAddName(name, legacy) {
+  resolveAndAddName(name, legacy, walletAddress) {
     resolveName(name).then((result) => {
       console.log(result);
-      fetch(`${NETWORK.coreApiUrl}/v2/prices/names/` + name).then(
-        (response) => {
-          return response.json().then((json) => {
-            let price = parseInt(json.amount);
-            let zonefileHash = Buffer.from(
-              result["zonefile-hash"].value.substr(2),
-              "hex"
-            );
-            this.setState({
-              names: [
-                {
-                  name,
-                  address: result.owner.value,
-                  data: result,
-                  legacy,
-                  price,
-                  zonefileHash,
-                  subdomain: isSubdomain(name),
-                },
-              ],
+      const subdomain = isSubdomain(name);
+      if (result) {
+        fetch(`${NETWORK.coreApiUrl}/v2/prices/names/` + name).then(
+          (response) => {
+            return response.json().then((json) => {
+              console.log(json);
+              let price = parseInt(json.amount);
+              let zonefileHash = Buffer.from(
+                result["zonefile-hash"].value.substr(2),
+                "hex"
+              );
+              this.setState({
+                names: [
+                  {
+                    name,
+                    address: result.owner.value,
+                    walletAddress,
+                    data: result,
+                    legacy,
+                    price,
+                    zonefileHash,
+                    subdomain,
+                  },
+                ],
+              });
             });
-          });
-        }
-      );
+          }
+        );
+      } else {
+        this.setState({
+          names: [
+            {
+              name,
+              address: "",
+              data: {
+                "lease-ending-at": { value: { value: "10000000000000" } },
+              },
+              legacy,
+              price: 0,
+              zonefileHash: Buffer.from([0]),
+              subdomain,
+            },
+          ],
+        });
+      }
     });
   }
 


### PR DESCRIPTION
This PR
* fixes #4 
* adds a "search by index" button that allows to renew legacy names on any index

The UX is ugly. It might be helpful to view the browser console during this process:
Steps to renew:
1. Login with account that has some stx in the wallet. This will be used to pay for all tx fees.
1. Agree to disclaimer
1. Wait until first name is found
1. Enter index number and press "search by index" button
2. Enter seed phrase
3. wait until the name is shown in the background (ignore "searching..")
4. close the search dialog
5. click on renew button
6. enter seed phrase
7. review the nonces and addresses and fee amount
8. click confirm and wait until confirm dialog closes
9. Start again by entering a new index and press "search by index" button
